### PR TITLE
Exclude makem-related files from GitHub Linguist statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+makem.sh linguist-vendored
+Makefile linguist-vendored


### PR DESCRIPTION
Hello, I noticed that this project is counted as a shell project on GitHub:

![image](https://user-images.githubusercontent.com/6270544/148490196-fe7f36a2-ed94-4b96-844e-5fcc9f57804d.png)

You can prevent this by adding `.gitattributes` file, as done in this PR.

For details, refer to [this blog post from GitHub](https://medium.com/@bolajiayodeji/introducing-github-linguist-8f09273ddea1).

[Many of your projects using makem](https://github.com/alphapapa?tab=repositories&q=&type=&language=shell&sort=) suffer from this issue. You can fix the issue by adding makem.sh to [vendor.yml](https://github.com/github/linguist/blob/master/lib/linguist/vendor.yml) of linguist.
